### PR TITLE
refactor!: remove `chunk-size` params

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -5,9 +5,9 @@ pub const USAGE: &str = "
 DS encryption proxy.
 
 Usage:
-  ds_proxy encrypt <input-file> <output-file> [--password-file=<password-file>] [--salt=<salt>] [--chunk-size=<chunk-size>] [--keyring-file=<keyring-file>]
-  ds_proxy decrypt <input-file> <output-file> [--password-file=<password-file>] [--salt=<salt>] [--chunk-size=<chunk-size>] [--keyring-file=<keyring-file>]
-  ds_proxy proxy [--address=<address>] [--bypass-ssl-certificate-check] [--password-file=<password-file>] [--salt=<salt>] [--chunk-size=<chunk-size>] [--upstream-url=<upstream-url>] [--local-encryption-directory=<local-encryption-directory>] [--write-once] [--keyring-file=<keyring-file>] [--s3-access-key=<s3-access-key>] [--s3-secret-key=<s3-secret-key>] [--s3-region=<s3-region>] [--bypass-s3-signature-check] [--backend-connection-timeout=<backend-connection-timeout>] [--redis-url=<redis-url>] [--redis-timeout-wait=<redis-timeout-wait>] [--redis-timeout-create=<redis-timeout-create>] [--redis-timeout-recycle=<redis-timeout-recycle>] [--redis-pool-max-size=<redis-pool-max-size>]
+  ds_proxy encrypt <input-file> <output-file> [--password-file=<password-file>] [--salt=<salt>] [--keyring-file=<keyring-file>]
+  ds_proxy decrypt <input-file> <output-file> [--password-file=<password-file>] [--salt=<salt>] [--keyring-file=<keyring-file>]
+  ds_proxy proxy [--address=<address>] [--bypass-ssl-certificate-check] [--password-file=<password-file>] [--salt=<salt>] [--upstream-url=<upstream-url>] [--local-encryption-directory=<local-encryption-directory>] [--write-once] [--keyring-file=<keyring-file>] [--s3-access-key=<s3-access-key>] [--s3-secret-key=<s3-secret-key>] [--s3-region=<s3-region>] [--bypass-s3-signature-check] [--backend-connection-timeout=<backend-connection-timeout>] [--redis-url=<redis-url>] [--redis-timeout-wait=<redis-timeout-wait>] [--redis-timeout-create=<redis-timeout-create>] [--redis-timeout-recycle=<redis-timeout-recycle>] [--redis-pool-max-size=<redis-pool-max-size>]
   ds_proxy add-key [--password-file=<password-file>] [--salt=<salt>] [--keyring-file=<keyring-file>]
   ds_proxy (-h | --help)
   ds_proxy --version
@@ -20,7 +20,6 @@ Options:
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct Args {
     pub flag_address: Option<String>,
-    pub flag_chunk_size: Option<usize>,
     pub arg_input_file: Option<String>,
     pub flag_keyring_file: Option<String>,
     pub arg_output_file: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,6 @@ pub struct DecryptConfig {
 #[derive(Debug, Clone)]
 pub struct EncryptConfig {
     pub keyring: Keyring,
-    pub chunk_size: usize,
     pub input_file: String,
     pub output_file: String,
 }
@@ -40,7 +39,6 @@ pub struct EncryptConfig {
 pub struct HttpConfig {
     pub upstream_base_url: Url,
     pub keyring: Keyring,
-    pub chunk_size: usize,
     pub address: SocketAddr,
     pub local_encryption_directory: PathBuf,
     pub s3_config: Option<S3Config>,
@@ -76,20 +74,11 @@ impl Config {
             });
         }
 
-        let chunk_size = match &args.flag_chunk_size {
-            Some(chunk_size) => *chunk_size,
-            None => match env::var("DS_CHUNK_SIZE") {
-                Ok(chunk_str) => chunk_str.parse::<usize>().unwrap_or(DEFAULT_CHUNK_SIZE),
-                _ => DEFAULT_CHUNK_SIZE,
-            },
-        };
-
         let keyring = load_keyring(&keyring_file, password, salt);
 
         if args.cmd_encrypt {
             Config::Encrypt(EncryptConfig {
                 keyring,
-                chunk_size,
                 input_file: args.arg_input_file.clone().unwrap(),
                 output_file: args.arg_output_file.clone().unwrap(),
             })
@@ -187,7 +176,6 @@ impl Config {
 
             Config::Http(HttpConfig {
                 keyring,
-                chunk_size,
                 upstream_base_url,
                 address,
                 local_encryption_directory,
@@ -437,7 +425,6 @@ mod tests {
 
         HttpConfig {
             keyring,
-            chunk_size: DEFAULT_CHUNK_SIZE,
             upstream_base_url: normalize_and_parse_upstream_url(upstream_base_url.to_string()),
             address: "127.0.0.1:1234".to_socket_addrs().unwrap().next().unwrap(),
             local_encryption_directory: PathBuf::from(DEFAULT_LOCAL_ENCRYPTION_DIRECTORY),

--- a/src/file.rs
+++ b/src/file.rs
@@ -19,7 +19,7 @@ pub fn encrypt(config: EncryptConfig) {
     let encoder = Encoder::new(
         key,
         key_id,
-        config.chunk_size,
+        DEFAULT_CHUNK_SIZE,
         Box::new(source_stream),
         None,
     );

--- a/src/http/handlers/encrypt_to_file.rs
+++ b/src/http/handlers/encrypt_to_file.rs
@@ -1,5 +1,7 @@
 use tokio::{fs::OpenOptions, io::AsyncWriteExt};
 
+use crate::config::DEFAULT_CHUNK_SIZE;
+
 use super::*;
 
 pub async fn encrypt_to_file(
@@ -14,7 +16,7 @@ pub async fn encrypt_to_file(
         .get_last_key()
         .expect("no key avalaible for encryption");
 
-    let mut encrypted_stream = Encoder::new(key, id, config.chunk_size, Box::new(payload), None);
+    let mut encrypted_stream = Encoder::new(key, id, DEFAULT_CHUNK_SIZE, Box::new(payload), None);
 
     log::info!("Encrypting to file: {}", filepath.display());
 

--- a/src/http/handlers/forward.rs
+++ b/src/http/handlers/forward.rs
@@ -1,3 +1,4 @@
+use crate::config::DEFAULT_CHUNK_SIZE;
 use crate::http::utils::s3_helper::sign_request;
 
 use super::*;
@@ -56,7 +57,7 @@ pub async fn forward(
     }
 
     let forward_length: Option<usize> = content_length(req.headers())
-        .map(|content_length| encrypted_content_length(content_length, config.chunk_size));
+        .map(|content_length| encrypted_content_length(content_length, DEFAULT_CHUNK_SIZE));
 
     for header in &FORWARD_REQUEST_HEADERS_TO_REMOVE {
         forwarded_req.headers_mut().remove(header);
@@ -73,7 +74,7 @@ pub async fn forward(
     let encrypted_stream = Encoder::<Error>::new(
         key,
         key_id,
-        config.chunk_size,
+        DEFAULT_CHUNK_SIZE,
         Box::new(convert_payload),
         Some(hasher_clone),
     );

--- a/tests/content_length_and_transfert_encoding.rs
+++ b/tests/content_length_and_transfert_encoding.rs
@@ -1,4 +1,4 @@
-use ds_proxy::crypto::header::*;
+use ds_proxy::{config::DEFAULT_CHUNK_SIZE, crypto::header::*};
 use sodiumoxide::crypto::secretstream::xchacha20poly1305::{ABYTES, HEADERBYTES};
 use std::fs::File;
 use std::io::Write;
@@ -15,10 +15,11 @@ async fn content_length_and_transfert_encoding() {
 
     // multiple of chunk size
     let nb_chunk = 2;
-    let original_length = nb_chunk * CHUNK_SIZE;
+    let original_length = nb_chunk * DEFAULT_CHUNK_SIZE;
     let content = vec![0; original_length];
 
-    let expected_encrypted_length = HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + CHUNK_SIZE);
+    let expected_encrypted_length =
+        HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + DEFAULT_CHUNK_SIZE);
 
     let (uploaded_length, downloaded_length) =
         uploaded_and_downloaded_content_length(&content).await;
@@ -28,11 +29,11 @@ async fn content_length_and_transfert_encoding() {
 
     // not a multiple of chunk size
     let nb_chunk = 2;
-    let original_length = nb_chunk * CHUNK_SIZE + 1;
+    let original_length = nb_chunk * DEFAULT_CHUNK_SIZE + 1;
     let content = vec![0; original_length];
 
     let expected_encrypted_length =
-        HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + CHUNK_SIZE) + ABYTES + 1;
+        HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + DEFAULT_CHUNK_SIZE) + ABYTES + 1;
 
     let (uploaded_length, downloaded_length) =
         uploaded_and_downloaded_content_length(&content).await;

--- a/tests/file_operations.rs
+++ b/tests/file_operations.rs
@@ -26,7 +26,6 @@ fn encrypt_and_decrypt() {
         .env("DS_KEYRING", DS_KEYRING)
         .env("DS_PASSWORD", PASSWORD)
         .env("DS_SALT", SALT)
-        .env("DS_CHUNK_SIZE", CHUNK_SIZE.to_string())
         .assert()
         .success();
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -19,7 +19,6 @@ pub use curl::*;
 pub const PASSWORD: &str = "plop";
 pub const SALT: &str = "12345678901234567890123456789012";
 pub const DS_KEYRING: &str = "tests/fixtures/keyring.toml";
-pub const CHUNK_SIZE: usize = 512;
 
 pub const COMPUTER_SVG_PATH: &str = "tests/fixtures/computer.svg";
 pub static COMPUTER_SVG_BYTES: Bytes =
@@ -99,8 +98,7 @@ pub fn launch_proxy(
         .arg("--s3-region=region")
         .env("DS_KEYRING", keyring)
         .env("DS_PASSWORD", PASSWORD)
-        .env("DS_SALT", SALT)
-        .env("DS_CHUNK_SIZE", CHUNK_SIZE.to_string());
+        .env("DS_SALT", SALT);
 
     if !enable_s3_signature_check {
         command.arg("--bypass-s3-signature-check");
@@ -179,7 +177,6 @@ pub fn decrypt(
         .env("DS_KEYRING", DS_KEYRING)
         .env("DS_PASSWORD", PASSWORD)
         .env("DS_SALT", SALT)
-        .env("DS_CHUNK_SIZE", CHUNK_SIZE.to_string())
         .assert()
         .success()
 }


### PR DESCRIPTION
In practice, the chunk_size params is never used, the default 16 * 1024 written in 06/2019 by 5e7e4cd8a718c423a79c03a20c4cfe2aba9a193b seems to work.

BREAKING CHANGE: the `chunk-size` and the `DS_CHUNK_SIZE` are now removed