### PR TITLE
add: Dockerfile used to build public docker images from debian package

### DIFF
--- a/Dockerfile_from_deb
+++ b/Dockerfile_from_deb
@@ -1,0 +1,17 @@
+FROM debian:13
+USER root
+
+# Add DS/DN repo
+RUN apt-get update && apt-get -y install curl gpg \
+    && curl -sS http://packages.demarches-simplifiees.fr/KEY.gpg | gpg --dearmor -o /usr/share/keyrings/demarches-simplifiees.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/demarches-simplifiees.gpg] http://packages.demarches-simplifiees.fr/jammy /" > /etc/apt/sources.list.d/packages_demarches_simplifiees_fr_jammy.list \
+    && apt-get update && apt-get -y install ds-proxy \
+    && adduser --disabled-password --gecos "" ds_proxy \
+    && apt-get remove --purge -y curl gpg \
+    && apt-get clean
+
+USER ds_proxy
+
+EXPOSE 4444
+
+ENTRYPOINT ["/usr/bin/ds_proxy"]


### PR DESCRIPTION
Provide the Dockerfile used to build public docker image from debian package as an alternative to the Dockerfile that build directly from sources.