### PR TITLE
feat(write-once): also cover S3 presigned URLs

### DIFF
--- a/src/http/middlewares/mod.rs
+++ b/src/http/middlewares/mod.rs
@@ -17,9 +17,13 @@ pub async fn ensure_write_once(
 ) -> Result<ServiceResponse<impl MessageBody>, Error> {
     let uri = req.uri();
 
-    let user_facing_uri = uri
-        .query()
-        .is_some_and(|query| query.contains("temp_url_expires"));
+    // Only guard presigned/user-facing writes: Swift TempURL (temp_url_expires)
+    // and S3 presigned URLs (x-amz-expires). Both flavors are covered so
+    // write-once holds in dual mode too.
+    let user_facing_uri = uri.query().is_some_and(|query| {
+        let query = query.to_ascii_lowercase();
+        query.contains("temp_url_expires") || query.contains("x-amz-expires")
+    });
 
     if !user_facing_uri {
         return next.call(req).await;

--- a/tests/ensure_write_once.rs
+++ b/tests/ensure_write_once.rs
@@ -95,6 +95,62 @@ mod tests {
 
     #[actix_web::test]
     #[serial(servers)]
+    async fn test_ensure_write_once_blocks_s3_presigned_url() {
+        let _redis_process = launch_redis_with_delay();
+
+        let config = RedisConfig {
+            url: Url::parse("redis://127.0.0.1:5555").unwrap(),
+            ..RedisConfig::default()
+        };
+        let redis_pool = configure_redis_pool(config).await;
+
+        let mut actix_app = App::new().service(
+            resource("/s3-path")
+                .guard(Get())
+                .wrap(from_fn(ensure_write_once))
+                .to(mock_success),
+        );
+
+        actix_app = actix_app.app_data(web::Data::new(WriteOnceService::new(redis_pool.clone())));
+
+        match redis_pool.get().await {
+            Ok(mut conn) => {
+                let _: () = conn
+                    .del(WriteOnceService::hash_key("/s3-path"))
+                    .await
+                    .unwrap();
+            }
+            Err(_err) => panic!("Failed to get Redis connection"),
+        }
+
+        let app = test::init_service(actix_app).await;
+
+        // First request: an S3 presigned URL (x-amz-expires) should pass and lock
+        let req = test::TestRequest::get()
+            .uri("/s3-path?X-Amz-Expires=60&X-Amz-Signature=abc")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 200);
+
+        // Subsequent presigned writes on the same path are denied, whatever the
+        // parameter casing.
+        let bypass_attempts = [
+            "/s3-path?X-Amz-Expires=60&X-Amz-Signature=abc", // identical
+            "/s3-path?x-amz-expires=60&x-amz-signature=def", // lowercased
+        ];
+
+        for uri in bypass_attempts {
+            let req = test::TestRequest::get().uri(uri).to_request();
+            let resp = test::try_call_service(&app, req).await;
+            match resp {
+                Ok(resp) => panic!("Expected 403 for {}, got {}", uri, resp.status()),
+                Err(err) => assert_eq!(err.error_response().status(), 403),
+            }
+        }
+    }
+
+    #[actix_web::test]
+    #[serial(servers)]
     async fn test_ensure_write_once_skips_private_uri() {
         let _redis_process = launch_redis_with_delay();
 


### PR DESCRIPTION
ensure_write_once only triggered on temp_url_expires (Swift). In dual mode an S3 presigned PUT (x-amz-expires) was not protected. Detection now covers both, case-insensitively.