### PR TITLE
break(socket): make the socket optional and customizable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,16 @@ l'hôte et le port de la cible de connexion sont utilisés ; le chemin et la que
 string viennent de l'upstream. Équivalent via variable d'environnement :
 `DS_CONNECT_URL`.
 
+#### Adresse TCP (`--address`)
+
+ds_proxy peut optionnellement écouter sur une adresse TCP :
+
+```
+--address 0.0.0.0:4444
+```
+
+Équivalent via variable d'environnement: `DS_ADDRESS`
+
 #### Socket Unix (`--socket-path`)
 
 ds_proxy peut optionnellement écouter sur une socket Unix :

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,18 @@ l'hôte et le port de la cible de connexion sont utilisés ; le chemin et la que
 string viennent de l'upstream. Équivalent via variable d'environnement :
 `DS_CONNECT_URL`.
 
+#### Socket Unix (`--socket-path`)
+
+ds_proxy peut optionnellement écouter sur une socket Unix :
+
+```
+--socket-path /run/ds_proxy/ds_proxy.socket
+```
+
+Équivalent via variable d'environnement: `DS_SOCKET_PATH`
+
+La socket est créée avec les permissions `0660`. Pour autoriser un appelant, ajoutez-le au groupe principal de l'utilisateur qui lance ds_proxy — par exemple pour nginx : `usermod -aG ds_proxy www-data`.
+
 ### Garder le mot de passe en mémoire
 
 Pour éviter que le mot de passe ne reste sur le disque et en suivant https://www.netmeister.org/blog/passing-passwords.html, nous utilisons `mkfifo` pour créer un named pipe qui nous permet de le transmettre en restant en mémoire.

--- a/src/args.rs
+++ b/src/args.rs
@@ -7,7 +7,7 @@ DS encryption proxy.
 Usage:
   ds_proxy encrypt <input-file> <output-file> [--password-file=<password-file>] [--keyring-file=<keyring-file>]
   ds_proxy decrypt <input-file> <output-file> [--password-file=<password-file>] [--keyring-file=<keyring-file>]
-  ds_proxy proxy [--address=<address>] [--bypass-ssl-certificate-check] [--password-file=<password-file>] [--upstream-url=<upstream-url>] [--connect-url=<connect-url>] [--local-encryption-directory=<local-encryption-directory>] [--write-once] [--keyring-file=<keyring-file>] [--s3-access-key=<s3-access-key>] [--s3-secret-key=<s3-secret-key>] [--s3-region=<s3-region>] [--bypass-s3-signature-check] [--backend-connection-timeout=<backend-connection-timeout>] [--redis-url=<redis-url>] [--redis-timeout-wait=<redis-timeout-wait>] [--redis-timeout-create=<redis-timeout-create>] [--redis-timeout-recycle=<redis-timeout-recycle>] [--redis-pool-max-size=<redis-pool-max-size>]
+  ds_proxy proxy [--address=<address>] [--socket-path=<socket-path>] [--bypass-ssl-certificate-check] [--password-file=<password-file>] [--upstream-url=<upstream-url>] [--connect-url=<connect-url>] [--local-encryption-directory=<local-encryption-directory>] [--write-once] [--keyring-file=<keyring-file>] [--s3-access-key=<s3-access-key>] [--s3-secret-key=<s3-secret-key>] [--s3-region=<s3-region>] [--bypass-s3-signature-check] [--backend-connection-timeout=<backend-connection-timeout>] [--redis-url=<redis-url>] [--redis-timeout-wait=<redis-timeout-wait>] [--redis-timeout-create=<redis-timeout-create>] [--redis-timeout-recycle=<redis-timeout-recycle>] [--redis-pool-max-size=<redis-pool-max-size>]
   ds_proxy init-keyring [--keyring-file=<keyring-file>]
   ds_proxy add-key [--password-file=<password-file>] [--keyring-file=<keyring-file>]
   ds_proxy rotate-password [--password-file=<password-file>] [--keyring-file=<keyring-file>]
@@ -22,6 +22,7 @@ Options:
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct Args {
     pub flag_address: Option<String>,
+    pub flag_socket_path: Option<String>,
     pub arg_input_file: Option<String>,
     pub flag_keyring_file: Option<String>,
     pub arg_output_file: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,7 @@ pub struct HttpConfig {
     pub connect_base_url: Option<Url>,
     pub keyring: Keyring,
     pub address: SocketAddr,
+    pub socket_path: Option<PathBuf>,
     pub local_encryption_directory: PathBuf,
     pub s3_config: Option<S3Config>,
     pub backend_connection_timeout: Duration,
@@ -164,6 +165,12 @@ impl Config {
             }
             .unwrap();
 
+            let socket_path =
+                optional_string_from(&args.flag_socket_path, "DS_SOCKET_PATH").map(PathBuf::from);
+            if let Some(path) = &socket_path {
+                log::info!("listening on unix socket: {:?}", path);
+            }
+
             let backend_connection_timeout = match &args.flag_backend_connection_timeout {
                 Some(timeout_u64) => Duration::from_secs(*timeout_u64),
                 None => match env::var("BACKEND_CONNECTION_TIMEOUT") {
@@ -216,6 +223,7 @@ impl Config {
                 upstream_base_url,
                 connect_base_url,
                 address,
+                socket_path,
                 local_encryption_directory,
                 s3_config,
                 backend_connection_timeout,
@@ -501,6 +509,7 @@ mod tests {
             upstream_base_url: normalize_and_parse_upstream_url(upstream_base_url.to_string()),
             connect_base_url: None,
             address: "127.0.0.1:1234".to_socket_addrs().unwrap().next().unwrap(),
+            socket_path: None,
             local_encryption_directory: PathBuf::from(DEFAULT_LOCAL_ENCRYPTION_DIRECTORY),
             s3_config: None,
             backend_connection_timeout: Duration::from_secs(1),

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,7 @@ pub struct HttpConfig {
     // and the Host header still reference upstream_base_url
     pub connect_base_url: Option<Url>,
     pub keyring: Keyring,
-    pub address: SocketAddr,
+    pub address: Option<SocketAddr>,
     pub socket_path: Option<PathBuf>,
     pub local_encryption_directory: PathBuf,
     pub s3_config: Option<S3Config>,
@@ -150,25 +150,24 @@ impl Config {
                 );
             }
 
-            let address = match &args.flag_address {
-                Some(address) => match address.to_socket_addrs() {
-                    Ok(mut sockets) => Some(sockets.next().unwrap()),
-                    _ => panic!("Unable to parse the address"),
-                },
-                None => match (env::var("DS_ADDRESS")
-                    .expect("Missing address, use DS_ADDRESS env or --address cli argument"))
-                .to_socket_addrs()
+            let address =
+                optional_string_from(&args.flag_address, "DS_ADDRESS").map(|address| match address
+                    .to_socket_addrs()
                 {
-                    Ok(mut sockets) => Some(sockets.next().unwrap()),
+                    Ok(mut sockets) => sockets.next().expect("Unable to parse the address"),
                     _ => panic!("Unable to parse the address"),
-                },
-            }
-            .unwrap();
+                });
 
             let socket_path =
                 optional_string_from(&args.flag_socket_path, "DS_SOCKET_PATH").map(PathBuf::from);
             if let Some(path) = &socket_path {
                 log::info!("listening on unix socket: {:?}", path);
+            }
+
+            if address.is_none() && socket_path.is_none() {
+                panic!(
+                    "Missing listener, use --address/DS_ADDRESS and/or --socket-path/DS_SOCKET_PATH"
+                );
             }
 
             let backend_connection_timeout = match &args.flag_backend_connection_timeout {
@@ -508,7 +507,7 @@ mod tests {
             keyring,
             upstream_base_url: normalize_and_parse_upstream_url(upstream_base_url.to_string()),
             connect_base_url: None,
-            address: "127.0.0.1:1234".to_socket_addrs().unwrap().next().unwrap(),
+            address: Some("127.0.0.1:1234".to_socket_addrs().unwrap().next().unwrap()),
             socket_path: None,
             local_encryption_directory: PathBuf::from(DEFAULT_LOCAL_ENCRYPTION_DIRECTORY),
             s3_config: None,

--- a/src/http/proxy.rs
+++ b/src/http/proxy.rs
@@ -13,20 +13,24 @@ use actix_web::{
 };
 use futures::FutureExt;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+use std::os::unix::fs::PermissionsExt;
 use std::time::Duration;
 
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 
+const SOCKET_MODE: u32 = 0o660;
+
 #[actix_web::main]
 pub async fn main(config: HttpConfig) -> std::io::Result<()> {
     let address = config.address;
+    let socket_path = config.socket_path.clone();
     let redis_pool = if config.write_once {
         Some(configure_redis_pool(config.redis_config.clone()).await)
     } else {
         None
     };
 
-    HttpServer::new(move || {
+    let server = HttpServer::new(move || {
         let mut awc_connector = awc::Connector::new().timeout(config.backend_connection_timeout); // max time to connect to remote host including dns name resolution
         if config.bypass_ssl_certificate_check {
             let mut ssl_builder = SslConnector::builder(SslMethod::tls()).unwrap();
@@ -80,8 +84,25 @@ pub async fn main(config: HttpConfig) -> std::io::Result<()> {
         app
     })
     .keep_alive(actix_http::KeepAlive::Disabled)
-    .bind_uds("/tmp/actix-uds.socket")?
-    .bind(address)?
-    .run()
-    .await
+    .bind(address)?;
+
+    let server = match socket_path {
+        Some(path) => {
+            let server = server.bind_uds(&path).map_err(|e| {
+                std::io::Error::new(e.kind(), format!("cannot bind unix socket {:?}: {}", path, e))
+            })?;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(SOCKET_MODE)).map_err(
+                |e| {
+                    std::io::Error::new(
+                        e.kind(),
+                        format!("cannot set permissions on unix socket {:?}: {}", path, e),
+                    )
+                },
+            )?;
+            server
+        }
+        None => server,
+    };
+
+    server.run().await
 }

--- a/src/http/proxy.rs
+++ b/src/http/proxy.rs
@@ -30,7 +30,7 @@ pub async fn main(config: HttpConfig) -> std::io::Result<()> {
         None
     };
 
-    let server = HttpServer::new(move || {
+    let mut server = HttpServer::new(move || {
         let mut awc_connector = awc::Connector::new().timeout(config.backend_connection_timeout); // max time to connect to remote host including dns name resolution
         if config.bypass_ssl_certificate_check {
             let mut ssl_builder = SslConnector::builder(SslMethod::tls()).unwrap();
@@ -83,26 +83,28 @@ pub async fn main(config: HttpConfig) -> std::io::Result<()> {
 
         app
     })
-    .keep_alive(actix_http::KeepAlive::Disabled)
-    .bind(address)?;
+    .keep_alive(actix_http::KeepAlive::Disabled);
 
-    let server = match socket_path {
-        Some(path) => {
-            let server = server.bind_uds(&path).map_err(|e| {
-                std::io::Error::new(e.kind(), format!("cannot bind unix socket {:?}: {}", path, e))
-            })?;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(SOCKET_MODE)).map_err(
-                |e| {
-                    std::io::Error::new(
-                        e.kind(),
-                        format!("cannot set permissions on unix socket {:?}: {}", path, e),
-                    )
-                },
-            )?;
-            server
-        }
-        None => server,
-    };
+    if let Some(address) = address {
+        server = server.bind(address)?;
+    }
+
+    if let Some(path) = socket_path {
+        server = server.bind_uds(&path).map_err(|e| {
+            std::io::Error::new(
+                e.kind(),
+                format!("cannot bind unix socket {:?}: {}", path, e),
+            )
+        })?;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(SOCKET_MODE)).map_err(
+            |e| {
+                std::io::Error::new(
+                    e.kind(),
+                    format!("cannot set permissions on unix socket {:?}: {}", path, e),
+                )
+            },
+        )?;
+    }
 
     server.run().await
 }

--- a/tests/helpers/curl.rs
+++ b/tests/helpers/curl.rs
@@ -104,7 +104,7 @@ pub fn curl_socket_get(url: &str) -> Output {
     Command::new("curl")
         .arg("-XGET")
         .arg("--unix-socket")
-        .arg("/tmp/actix-uds.socket")
+        .arg(super::UNIX_SOCKET_PATH)
         .arg(url)
         .output()
         .expect("failed to perform download")

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -18,6 +18,7 @@ pub use curl::*;
 
 pub const PASSWORD: &str = "plop";
 pub const DS_KEYRING: &str = "tests/fixtures/keyring.toml";
+pub const UNIX_SOCKET_PATH: &str = "/tmp/actix-uds.socket";
 
 pub const COMPUTER_SVG_PATH: &str = "tests/fixtures/computer.svg";
 pub static COMPUTER_SVG_BYTES: Bytes =
@@ -107,6 +108,7 @@ pub fn launch_proxy(
     command
         .arg("proxy")
         .arg("--address=localhost:4444")
+        .arg(format!("--socket-path={}", UNIX_SOCKET_PATH))
         .arg("--upstream-url=http://localhost:3333/jail/cell")
         .arg("--s3-access-key=key")
         .arg("--s3-secret-key=secret")
@@ -137,6 +139,7 @@ pub fn launch_proxy_with_connect_url(upstream_url: &str, connect_url: &str) -> C
     command
         .arg("proxy")
         .arg("--address=localhost:4444")
+        .arg(format!("--socket-path={}", UNIX_SOCKET_PATH))
         .arg(format!("--upstream-url={}", upstream_url))
         .arg(format!("--connect-url={}", connect_url))
         .arg("--s3-access-key=key")

--- a/tests/socket_permissions.rs
+++ b/tests/socket_permissions.rs
@@ -1,0 +1,24 @@
+use std::os::unix::fs::PermissionsExt;
+use std::{fs, thread, time};
+
+mod helpers;
+pub use helpers::*;
+
+#[test]
+#[serial(servers)]
+fn socket_is_created_with_0660_permissions() {
+    /*
+    This test:
+     - spawns a ds proxy listening on a unix socket
+     - checks that the socket file is created with 0660 permissions
+       (read/write for the owner and the group, nothing for others)
+    */
+    let _proxy_server = launch_proxy(PrintServerLogs::No, None, None, false);
+    thread::sleep(time::Duration::from_secs(2));
+
+    let metadata = fs::metadata(UNIX_SOCKET_PATH)
+        .unwrap_or_else(|_| panic!("the unix socket {} should exist", UNIX_SOCKET_PATH));
+    let mode = metadata.permissions().mode() & 0o777;
+
+    assert_eq!(mode, 0o660, "expected socket mode 0660, got {:o}", mode);
+}


### PR DESCRIPTION
- New `--socket-path` flag (env: `DS_SOCKET_PATH`) to choose the Unix socket location; without it, no socket is created.
- The socket is created with `0660` permissions (read/write for its owner and group only).
- The TCP listener (`--address` / `DS_ADDRESS`) is now optional, so ds_proxy can listen on the Unix socket only.
- At least one listener (`--address` or `--socket-path`) is required; ds_proxy exits immediately if neither is set.