### PR TITLE
fix(fetch): répondre 206 quand une plage est servie

### DIFF
--- a/src/http/handlers/fetch.rs
+++ b/src/http/handlers/fetch.rs
@@ -5,6 +5,7 @@ use crate::http::utils::{
     s3_helper::sign_request,
 };
 use actix_files::HttpRange;
+use actix_web::http::StatusCode;
 use actix_web::web::Bytes;
 
 pub async fn fetch(
@@ -50,7 +51,9 @@ pub async fn fetch(
         error!("fetch status error {:?} {:?}", req, res);
     }
 
-    let mut client_resp = HttpResponse::build(res.status());
+    let upstream_status = res.status();
+
+    let mut client_resp = HttpResponse::build(upstream_status);
 
     for header in res
         .headers()
@@ -76,10 +79,13 @@ pub async fn fetch(
 
         let range = raw_range.map(|r| HttpRange::parse(r, length.try_into().unwrap()));
 
-        match range {
-            Some(Ok(v)) => {
-                let r = v.first().unwrap();
+        let served_range = match (upstream_status, range) {
+            (StatusCode::OK, Some(Ok(v))) => v.first().copied().filter(|r| r.length > 0),
+            _ => None,
+        };
 
+        match served_range {
+            Some(r) => {
                 let range_start = r.start.try_into().unwrap();
                 let range_end = (r.start + r.length - 1).try_into().unwrap();
 
@@ -90,9 +96,12 @@ pub async fn fetch(
                     format!("bytes {}-{}/{}", range_start, range_end, length),
                 ));
 
+                // What we hand back is a slice, and only a 206 says so
+                client_resp.status(StatusCode::PARTIAL_CONTENT);
+
                 Ok(client_resp.no_chunking(r.length).streaming(pe))
             }
-            _ => Ok(client_resp.no_chunking(length as u64).streaming(decoder)),
+            None => Ok(client_resp.no_chunking(length as u64).streaming(decoder)),
         }
     } else {
         Ok(client_resp.streaming(decoder))

--- a/tests/helpers/curl.rs
+++ b/tests/helpers/curl.rs
@@ -179,3 +179,22 @@ where
     let file = std::fs::File::open(filename).unwrap();
     std::io::BufReader::new(file).lines()
 }
+
+// Response headers, lowercased, for a GET carrying the given raw Range value.
+pub fn curl_range_headers(url: &str, range: &str) -> String {
+    let response = Command::new("curl")
+        .arg("-XGET")
+        .arg(url)
+        .arg("-H")
+        .arg(format!("Range: {}", range))
+        .arg("--dump-header")
+        .arg("-")
+        .arg("-o")
+        .arg("/dev/null")
+        .arg("-s")
+        .output()
+        .expect("failed to perform download")
+        .stdout;
+
+    String::from_utf8_lossy(&response).to_lowercase()
+}

--- a/tests/upload_and_download.rs
+++ b/tests/upload_and_download.rs
@@ -89,3 +89,96 @@ fn check_s3_signature() {
         "Invalid S3 signature".to_string()
     );
 }
+
+#[test]
+#[serial(servers)]
+fn a_served_range_is_a_partial_response() {
+    /*
+    A range is extracted from the stream ds_proxy decrypts, not from the upstream, which
+    never sees the header. The response must still say what it is: outside 206 and 416,
+    `Content-Range` has no defined meaning (RFC 9110 §14.4), so a shared cache is free to
+    store this slice as the whole representation of an URL others read in full.
+    */
+    let uploaded_path = "tests/fixtures/server-static/uploads/jail/cell/partial";
+
+    ensure_is_absent(uploaded_path);
+
+    let _proxy_node_and_redis = ProxyAndNode::start();
+
+    curl_put(COMPUTER_SVG_PATH, "localhost:4444/upstream/partial");
+
+    let headers = curl_range_headers("localhost:4444/upstream/partial", "bytes=0-10");
+    assert!(
+        headers.contains("http/1.1 206 partial content"),
+        "expected a 206, got:\n{}",
+        headers
+    );
+    assert!(
+        headers.contains(&format!(
+            "content-range: bytes 0-10/{}",
+            COMPUTER_SVG_BYTES.len()
+        )),
+        "expected a content-range over the cleartext length, got:\n{}",
+        headers
+    );
+    assert!(
+        headers.contains("content-length: 11"),
+        "expected the length of the slice, got:\n{}",
+        headers
+    );
+
+    // an upstream that did not answer 200 is relayed whole: an error page is not a slice,
+    // and carries no content-range to pretend otherwise
+    let missing = curl_range_headers("localhost:4444/upstream/never_uploaded", "bytes=0-10");
+    assert!(
+        missing.contains("http/1.1 404"),
+        "expected the upstream status, got:\n{}",
+        missing
+    );
+    assert!(
+        !missing.contains("content-range"),
+        "an error page is not a range, got:\n{}",
+        missing
+    );
+    let missing_body = curl_range_get("localhost:4444/upstream/never_uploaded", 0, 10);
+    assert!(
+        missing_body.stdout.len() > 11,
+        "the error page must be relayed whole, got {} bytes",
+        missing_body.stdout.len()
+    );
+
+    // a range over an object stored in the clear is served the same way
+    let plain_path = "tests/fixtures/server-static/uploads/jail/cell/plain";
+    std::fs::write(plain_path, b"ABCDEFGHIJKLMNOPQRSTUVWXYZ").unwrap();
+    let plain = curl_range_headers("localhost:4444/upstream/plain", "bytes=5-9");
+    assert!(
+        plain.contains("http/1.1 206 partial content")
+            && plain.contains("content-range: bytes 5-9/26"),
+        "expected a 206 over the plaintext object, got:\n{}",
+        plain
+    );
+    assert_eq!(
+        curl_range_get("localhost:4444/upstream/plain", 5, 9).stdout,
+        b"FGHIJ"
+    );
+
+    // A range designating no byte is no range at all, and must not take the extracting
+    // path: `HttpRange` yields an empty vec for a header it cannot use, and a zero-length
+    // range for a suffix range over an empty object — both of which used to reach the
+    // subtraction and the `first().unwrap()` below it.
+    let unusable = curl_range_headers("localhost:4444/upstream/partial", "bytes=");
+    assert!(
+        unusable.contains("http/1.1 200 ok") && !unusable.contains("content-range"),
+        "expected an untouched 200, got:\n{}",
+        unusable
+    );
+
+    let empty_path = "tests/fixtures/server-static/uploads/jail/cell/empty";
+    std::fs::write(empty_path, b"").unwrap();
+    let empty = curl_range_headers("localhost:4444/upstream/empty", "bytes=-5");
+    assert!(
+        empty.contains("http/1.1 200 ok") && !empty.contains("content-range"),
+        "expected an untouched 200, got:\n{}",
+        empty
+    );
+}


### PR DESCRIPTION
Une plage est extraite du flux que ds_proxy déchiffre, pas de l'amont, qui ne voit jamais l'en-tête `Range` (on le retire : l'objet est chiffré, une plage en clair ne désigne aucune plage de chiffré). Le statut relayé était donc celui de Swift — un 200 qui répond pour l'objet entier — accompagné d'un `Content-Range`.

Or RFC 9110 §14.4 : « *The Content-Range header field has no meaning for status codes that do not explicitly describe its semantic. For this specification, only the 206 (Partial Content) and 416 (Range Not Satisfiable) status codes describe a meaning for Content-Range.* » Un cache partagé était donc libre de retenir la tranche comme la représentation complète de l'URL, et un client qui se fie au statut — le contrat HTTP normal — recevait un fichier tronqué en le croyant entier :

```
Range: bytes=2000-  →  HTTP/1.1 200 OK
                       content-length: 3882      ← la fin d'un fichier de 5882
```

La plage et le 206 sont désormais décidés ensemble, et seulement pour un amont 200 : un 206 signifie que le corps est la tranche, et rien d'autre ne le signifie. Deux conséquences, chacune couverte par un test :

- une réponse d'erreur est relayée **entière**, au lieu d'être tronquée à la taille de la plage et étiquetée d'un `Content-Range` ;
- une plage ne désignant aucun octet — ce que rend `HttpRange` pour une plage suffixe sur un objet vide, ou pour un en-tête inexploitable — prend le même chemin qu'une absence de plage.

`Accept-Ranges` n'est pas ajouté : l'amont l'envoie déjà et il est relayé tel quel.

### Compatibilité

Le client Rails lit exactement les mêmes octets qu'avant (même SHA-256), avec ou sans ce correctif : il accepte les deux formes le temps de la bascule. `S3Service#download_chunk` d'Active Storage ne regarde pas le statut, et 206 est ce qu'un vrai S3 répond à cette requête.

Ref demarche-numerique/demarche.numerique.gouv.fr#13739 — à déployer avant elle.
